### PR TITLE
ensure integration test works on merge_group trigger

### DIFF
--- a/.github/workflows/check-signed-commits.yaml
+++ b/.github/workflows/check-signed-commits.yaml
@@ -1,7 +1,6 @@
 name: Check signed commits
 on: 
   pull_request_target:
-  merge_group:
 
 jobs:
   check-signed-commits:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -20,17 +20,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
 
       - name: Go vendor to speed up docker build
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         run: go mod vendor
 
       - name: Start JIMM (pull request)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         uses: ./.github/actions/test-server
         with:
           jimm-version: dev


### PR DESCRIPTION
Ensure integration test works on merge_group trigger and remove merge_group trigger from the "Check signed commits" workflow. Make sure to also unmark the "Check signed commits" action as "required" otherwise it will never run on merge_group.

This should fix the issues with https://github.com/canonical/jimm/pull/1431
